### PR TITLE
Add web-based ChatGPT backup manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.db
+.env
+.venv/
+.env.local
+.DS_Store
+.idea/
+.vscode/
+.mypy_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+*.log
+# Application data directories
+/data/downloads/
+/data/extracted/
+/data/indexes/
+/data/tmp/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
-# chatgpt-backup-manager
-Parse and search ChatGPT backups 
+# ChatGPT Backup Manager
+
+A web-based, text-first control panel for taming humongous ChatGPT backup archives. Point the app at the
+download link from OpenAI, let it stream the giant zip, unpack it without freezing your machine, and build
+a fast search index for all of your conversations.
+
+## Features
+
+- **Reliable download manager** – Streams massive archives directly to disk with retry and resume support.
+- **Responsive unpacking** – Extracts the archive in a background worker thread, updating progress as it goes.
+- **Searchable index** – Builds a SQLite FTS5 index of the exported conversations so queries return instantly.
+- **Text-centric UI** – Minimalist monospace interface that keeps everything legible and lightweight.
+- **REST API** – Access job status and search results programmatically.
+
+## Getting started
+
+1. Install dependencies (Python 3.11+):
+
+   ```bash
+   pip install -e .
+   ```
+
+2. Launch the development server:
+
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+3. Open `http://127.0.0.1:8000` in your browser. Paste the download URL from the OpenAI export email and
+   watch the job progress through download, extraction, and indexing.
+
+4. Once indexing is complete, head to the **Search** view, choose the finished job, and query your history.
+
+### CLI / API
+
+- `GET /api/jobs` – list tracked jobs.
+- `GET /api/jobs/{job_id}` – detailed job information.
+- `GET /api/jobs/{job_id}/search?q=...` – search within a completed backup.
+
+## Project layout
+
+```
+app/
+  archive.py     # extraction helpers
+  config.py      # shared paths and constants
+  indexer.py     # FTS5 index builder and query helpers
+  main.py        # FastAPI application and routes
+  manager.py     # job orchestration (download/extract/index)
+  models.py      # job dataclasses and Pydantic schemas
+  utils.py       # misc helpers
+templates/       # text-based UI templates
+```
+
+All persistent data (downloads, extracted archives, indexes) live under `data/` next to the source tree.
+The directories are created automatically on first run and are excluded from version control.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""ChatGPT backup manager application package."""

--- a/app/archive.py
+++ b/app/archive.py
@@ -1,0 +1,55 @@
+"""Archive extraction helpers."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from zipfile import ZipFile
+
+from .models import Job
+
+
+def extract_archive(job: Job) -> None:
+    """Unpack the downloaded archive into the job's extraction directory."""
+
+    extract_path = job.extract_path
+    extract_path.mkdir(parents=True, exist_ok=True)
+
+    if any(extract_path.iterdir()):
+        _clear_directory(extract_path)
+
+    with ZipFile(job.archive_path) as archive:
+        members = archive.infolist()
+        total = len(members)
+        for index, member in enumerate(members, start=1):
+            _extract_member(archive, member, extract_path)
+            if total:
+                progress = index / total
+                detail = f"Extracted {index}/{total} entries"
+                job.set_progress(progress, detail=detail)
+
+
+def _clear_directory(path: Path) -> None:
+    for item in path.iterdir():
+        if item.is_dir():
+            shutil.rmtree(item)
+        else:
+            item.unlink()
+
+
+def _extract_member(archive: ZipFile, member, target_dir: Path) -> None:
+    target_path = _safe_destination(target_dir, member.filename)
+    if member.is_dir():
+        target_path.mkdir(parents=True, exist_ok=True)
+        return
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    with archive.open(member, "r") as src, target_path.open("wb") as dst:
+        shutil.copyfileobj(src, dst, length=1024 * 1024)
+
+
+def _safe_destination(base_dir: Path, name: str) -> Path:
+    destination = base_dir / name
+    resolved = destination.resolve()
+    if not str(resolved).startswith(str(base_dir.resolve())):
+        raise ValueError(f"Archive member escapes extraction directory: {name}")
+    return resolved

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,17 @@
+"""Application configuration utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+APP_ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = APP_ROOT / "data"
+DOWNLOAD_DIR = DATA_DIR / "downloads"
+EXTRACT_DIR = DATA_DIR / "extracted"
+INDEX_DIR = DATA_DIR / "indexes"
+TMP_DIR = DATA_DIR / "tmp"
+
+for directory in (DATA_DIR, DOWNLOAD_DIR, EXTRACT_DIR, INDEX_DIR, TMP_DIR):
+    directory.mkdir(parents=True, exist_ok=True)
+
+DEFAULT_DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MiB

--- a/app/indexer.py
+++ b/app/indexer.py
@@ -1,0 +1,200 @@
+"""Search index builder for ChatGPT backups."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+from .models import Job
+
+
+def build_index_for_job(job: Job) -> None:
+    """Create or refresh the search index for a processed job."""
+
+    build_index(job.extract_path, job.index_path, job)
+
+
+def build_index(extracted_dir: Path, index_path: Path, job: Job | None = None) -> None:
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(index_path)
+    try:
+        _initialise_schema(connection)
+        connection.execute("DELETE FROM conversations")
+        connection.commit()
+
+        conversation_file = extracted_dir / "conversations.json"
+        if conversation_file.exists():
+            conversations = _load_conversations(conversation_file)
+            _insert_conversations(connection, conversations, job)
+        else:
+            documents = list(_walk_text_documents(extracted_dir))
+            _insert_documents(connection, documents, job)
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def query_index(index_path: Path, query: str, limit: int = 25) -> List[dict[str, str]]:
+    connection = sqlite3.connect(index_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        cursor = connection.execute(
+            "SELECT conversation_id, title, timestamp, snippet(conversations, 3, '[', ']', '…', 10) AS snippet "
+            "FROM conversations WHERE conversations MATCH ? ORDER BY rank LIMIT ?",
+            (query, limit),
+        )
+        rows = cursor.fetchall()
+        return [
+            {
+                "conversation_id": row["conversation_id"],
+                "title": row["title"],
+                "timestamp": row["timestamp"],
+                "snippet": row["snippet"],
+            }
+            for row in rows
+        ]
+    finally:
+        connection.close()
+
+
+def _initialise_schema(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS conversations USING fts5(
+            conversation_id UNINDEXED,
+            title,
+            timestamp,
+            content
+        )
+        """
+    )
+
+
+def _load_conversations(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("conversations", "items", "data"):
+            if key in data and isinstance(data[key], list):
+                return data[key]
+    return []
+
+
+def _insert_conversations(connection: sqlite3.Connection, conversations: List[dict], job: Job | None) -> None:
+    total = len(conversations) or 1
+    for index, conversation in enumerate(conversations, start=1):
+        conv_id = str(conversation.get("id") or index)
+        title = conversation.get("title") or f"Conversation {index}"
+        timestamp = _format_timestamp(conversation.get("create_time") or conversation.get("update_time"))
+        content = _conversation_to_text(conversation)
+        connection.execute(
+            "INSERT INTO conversations (conversation_id, title, timestamp, content) VALUES (?, ?, ?, ?)",
+            (conv_id, title, timestamp, content),
+        )
+        if job:
+            progress = index / total
+            detail = f"Indexed {index}/{total} conversations"
+            job.set_progress(progress, detail=detail)
+
+
+def _insert_documents(connection: sqlite3.Connection, documents: List[Tuple[str, str, str]], job: Job | None) -> None:
+    total = len(documents) or 1
+    for index, (identifier, title, content) in enumerate(documents, start=1):
+        connection.execute(
+            "INSERT INTO conversations (conversation_id, title, timestamp, content) VALUES (?, ?, ?, ?)",
+            (identifier, title, "", content),
+        )
+        if job:
+            progress = index / total
+            detail = f"Indexed {index}/{total} documents"
+            job.set_progress(progress, detail=detail)
+
+
+def _conversation_to_text(conversation: dict) -> str:
+    parts: List[str] = []
+    title = conversation.get("title")
+    if title:
+        parts.append(str(title))
+    mapping = conversation.get("mapping")
+    if isinstance(mapping, dict):
+        ordered_messages = _order_messages(mapping)
+        for message in ordered_messages:
+            role = message.get("author", {}).get("role", "unknown")
+            text = _extract_message_text(message)
+            if text:
+                parts.append(f"{role}: {text}")
+    return "\n\n".join(parts)
+
+
+def _order_messages(mapping: dict) -> List[dict]:
+    messages = []
+    for node in mapping.values():
+        message = node.get("message") if isinstance(node, dict) else None
+        if message:
+            messages.append(message)
+    messages.sort(key=lambda m: m.get("create_time") or 0)
+    return messages
+
+
+def _extract_message_text(message: dict) -> str:
+    content = message.get("content")
+    if isinstance(content, dict):
+        if content.get("parts"):
+            collected: List[str] = []
+            for part in content["parts"]:
+                text = _normalise_part(part)
+                if text:
+                    collected.append(text)
+            return "\n".join(collected)
+        if content.get("text"):
+            return str(content["text"])
+    if isinstance(content, list):
+        collected = []
+        for part in content:
+            text = _normalise_part(part)
+            if text:
+                collected.append(text)
+        return "\n".join(collected)
+    if isinstance(content, str):
+        return content
+    return ""
+
+
+def _normalise_part(part) -> str:
+    if isinstance(part, str):
+        return part.strip()
+    if isinstance(part, dict):
+        if "text" in part and isinstance(part["text"], str):
+            return part["text"].strip()
+        if "value" in part and isinstance(part["value"], str):
+            return part["value"].strip()
+    return ""
+
+
+def _walk_text_documents(root: Path) -> Iterator[Tuple[str, str, str]]:
+    for path in root.rglob("*"):
+        if path.is_dir():
+            continue
+        if path.suffix.lower() not in {".json", ".txt", ".md", ".csv"}:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        yield (str(path.relative_to(root)), path.name, content)
+
+
+def _format_timestamp(value: Optional[float]) -> str:
+    if value in (None, ""):
+        return ""
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    return dt.isoformat()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,101 @@
+"""Entry point for the FastAPI application."""
+
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from .manager import JobManager
+from .models import JobInfo
+
+app = FastAPI(title="ChatGPT Backup Manager", version="0.1.0")
+templates = Jinja2Templates(directory="templates")
+manager = JobManager()
+
+
+async def get_manager() -> JobManager:
+    return manager
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request, manager: JobManager = Depends(get_manager)) -> HTMLResponse:
+    jobs = await manager.list_jobs()
+    return templates.TemplateResponse("index.html", {"request": request, "jobs": jobs})
+
+
+@app.post("/jobs", response_class=HTMLResponse)
+async def create_job(
+    request: Request,
+    url: str = Form(..., description="Direct download link to the ChatGPT backup archive"),
+    manager: JobManager = Depends(get_manager),
+) -> RedirectResponse:
+    job = await manager.create_job(url.strip())
+    return RedirectResponse(url=request.url_for("job_detail", job_id=job.id), status_code=303)
+
+
+@app.get("/jobs/{job_id}", response_class=HTMLResponse)
+async def job_detail(request: Request, job_id: str, manager: JobManager = Depends(get_manager)) -> HTMLResponse:
+    job = await manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return templates.TemplateResponse("job.html", {"request": request, "job": job})
+
+
+@app.get("/search", response_class=HTMLResponse)
+async def search(
+    request: Request,
+    job_id: str | None = None,
+    q: str | None = None,
+    manager: JobManager = Depends(get_manager),
+) -> HTMLResponse:
+    jobs = await manager.list_jobs()
+    selected_job: JobInfo | None = None
+    results = []
+    error = None
+    if job_id:
+        selected_job = next((job for job in jobs if job.id == job_id), None)
+        if not selected_job:
+            error = "Unknown job selected"
+        elif q:
+            try:
+                results = await manager.search(job_id, q)
+            except Exception as exc:  # pragma: no cover - surfaces to UI
+                error = str(exc)
+    context = {
+        "request": request,
+        "jobs": jobs,
+        "selected_job": selected_job,
+        "query": q or "",
+        "results": results,
+        "error": error,
+    }
+    return templates.TemplateResponse("search.html", context)
+
+
+# API endpoints -------------------------------------------------------------
+
+
+@app.get("/api/jobs")
+async def api_list_jobs(manager: JobManager = Depends(get_manager)):
+    jobs = await manager.list_jobs()
+    return [job.dict() for job in jobs]
+
+
+@app.get("/api/jobs/{job_id}")
+async def api_get_job(job_id: str, manager: JobManager = Depends(get_manager)):
+    job = await manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job.dict()
+
+
+@app.get("/api/jobs/{job_id}/search")
+async def api_search(job_id: str, q: str, manager: JobManager = Depends(get_manager)):
+    try:
+        results = await manager.search(job_id, q)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Job not found")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return results

--- a/app/manager.py
+++ b/app/manager.py
@@ -1,0 +1,163 @@
+"""Background processing manager for backup ingestion jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+import httpx
+
+from . import config, indexer
+from .archive import extract_archive
+from .models import Job, JobInfo, JobStatus
+from .utils import human_readable_bytes
+
+logger = logging.getLogger(__name__)
+
+
+class JobManager:
+    """Coordinates download, extraction, and indexing of backups."""
+
+    def __init__(self) -> None:
+        self._jobs: Dict[str, Job] = {}
+        self._lock = asyncio.Lock()
+
+    async def create_job(self, url: str) -> Job:
+        job_id = uuid4().hex
+        archive_path = config.DOWNLOAD_DIR / f"{job_id}.zip"
+        extract_path = config.EXTRACT_DIR / job_id
+        index_path = config.INDEX_DIR / f"{job_id}.sqlite3"
+        job = Job(
+            id=job_id,
+            url=url,
+            archive_path=archive_path,
+            extract_path=extract_path,
+            index_path=index_path,
+        )
+        async with self._lock:
+            self._jobs[job_id] = job
+        asyncio.create_task(self._run_job(job))
+        return job
+
+    async def list_jobs(self) -> List[JobInfo]:
+        async with self._lock:
+            jobs = list(self._jobs.values())
+        return [JobInfo.from_job(job) for job in jobs]
+
+    async def get_job(self, job_id: str) -> Optional[JobInfo]:
+        async with self._lock:
+            job = self._jobs.get(job_id)
+        if job is None:
+            return None
+        return JobInfo.from_job(job)
+
+    async def get_job_internal(self, job_id: str) -> Optional[Job]:
+        async with self._lock:
+            return self._jobs.get(job_id)
+
+    async def search(self, job_id: str, query: str, limit: int = 25) -> List[dict[str, str]]:
+        job = await self.get_job_internal(job_id)
+        if not job:
+            raise KeyError(f"No job with id {job_id}")
+        if job.status != JobStatus.COMPLETED:
+            raise RuntimeError("Job has not completed indexing yet")
+        return indexer.query_index(job.index_path, query, limit)
+
+    async def _run_job(self, job: Job) -> None:
+        try:
+            job.set_stage("queued", JobStatus.PENDING, detail="Awaiting processing")
+            await asyncio.sleep(0)
+            await self._download(job)
+            job.set_stage("downloaded", JobStatus.DOWNLOADED, detail="Archive downloaded")
+            await self._extract(job)
+            job.set_stage("extracted", JobStatus.EXTRACTED, detail="Files unpacked")
+            await self._index(job)
+            job.set_stage("completed", JobStatus.COMPLETED, detail="Index ready")
+            job.set_progress(1.0)
+        except Exception as exc:  # pragma: no cover - safety net
+            logger.exception("Job %s failed", job.id)
+            job.set_stage("failed", JobStatus.FAILED, detail=str(exc))
+            job.update(message=str(exc))
+
+    async def _download(self, job: Job) -> None:
+        job.set_stage("downloading", JobStatus.DOWNLOADING, detail="Starting download")
+        job.set_progress(0.0)
+        retries = 3
+        backoff = 2
+        last_error: Optional[Exception] = None
+        for attempt in range(1, retries + 1):
+            try:
+                await self._stream_download(job)
+                return
+            except Exception as exc:
+                last_error = exc
+                wait_for = backoff ** attempt
+                job.set_stage(
+                    "downloading",
+                    detail=f"Retry {attempt}/{retries} after error: {exc}"
+                )
+                await asyncio.sleep(wait_for)
+        raise RuntimeError(f"Download failed after {retries} attempts: {last_error}")
+
+    async def _stream_download(self, job: Job) -> None:
+        resume_position = 0
+        if job.archive_path.exists():
+            resume_position = job.archive_path.stat().st_size
+
+        headers = {"User-Agent": "ChatGPT-Backup-Manager/1.0"}
+        if resume_position:
+            headers["Range"] = f"bytes={resume_position}-"
+
+        async with httpx.AsyncClient(timeout=None, follow_redirects=True) as client:
+            async with client.stream("GET", job.url, headers=headers) as response:
+                response.raise_for_status()
+                if resume_position and response.status_code != 206:
+                    # Server ignored the range request; restart from scratch
+                    resume_position = 0
+                    headers.pop("Range", None)
+                    if job.archive_path.exists():
+                        job.archive_path.unlink()
+                    job.update(bytes_downloaded=0)
+                total = response.headers.get("Content-Length")
+                if total is not None:
+                    total_bytes = int(total)
+                    if resume_position and response.status_code == 206:
+                        total_bytes += resume_position
+                else:
+                    total_bytes = None
+                job.set_total_bytes(total_bytes)
+                if resume_position:
+                    job.update(bytes_downloaded=resume_position)
+                mode = "ab" if resume_position else "wb"
+                with open(job.archive_path, mode) as file_handle:
+                    async for chunk in response.aiter_bytes(config.DEFAULT_DOWNLOAD_CHUNK_SIZE):
+                        if not chunk:
+                            continue
+                        file_handle.write(chunk)
+                        job.bump_downloaded(len(chunk))
+                        detail = _format_download_detail(job)
+                        job.set_progress(job.progress, detail=detail)
+                        await asyncio.sleep(0)
+
+    async def _extract(self, job: Job) -> None:
+        job.set_stage("extracting", JobStatus.EXTRACTING, detail="Unpacking archive")
+        job.set_progress(0.0)
+        await asyncio.to_thread(extract_archive, job)
+        job.set_progress(1.0, detail="Extraction complete")
+
+    async def _index(self, job: Job) -> None:
+        job.set_stage("indexing", JobStatus.INDEXING, detail="Creating search index")
+        job.set_progress(0.0)
+        await asyncio.to_thread(indexer.build_index_for_job, job)
+        job.set_progress(1.0, detail="Indexing finished")
+
+
+def _format_download_detail(job: Job) -> str:
+    with job.lock:
+        downloaded = job.bytes_downloaded
+        total = job.total_bytes
+    if total:
+        return f"{human_readable_bytes(downloaded)} / {human_readable_bytes(total)}"
+    return f"{human_readable_bytes(downloaded)} downloaded"

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,153 @@
+"""Domain models for the ChatGPT backup manager."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Optional
+import threading
+
+from pydantic import BaseModel
+
+
+class JobStatus(str, Enum):
+    """Lifecycle states for a backup ingestion job."""
+
+    PENDING = "pending"
+    DOWNLOADING = "downloading"
+    DOWNLOADED = "downloaded"
+    EXTRACTING = "extracting"
+    EXTRACTED = "extracted"
+    INDEXING = "indexing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class Job:
+    """Represents the state of a backup processing job."""
+
+    id: str
+    url: str
+    archive_path: Path
+    extract_path: Path
+    index_path: Path
+    status: JobStatus = JobStatus.PENDING
+    stage: str = "pending"
+    stage_detail: Optional[str] = None
+    progress: Optional[float] = None
+    bytes_downloaded: int = 0
+    total_bytes: Optional[int] = None
+    message: Optional[str] = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+    lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
+
+    def update(self, **fields: Any) -> None:
+        """Safely update fields on the job."""
+
+        with self.lock:
+            for key, value in fields.items():
+                if not hasattr(self, key):
+                    raise AttributeError(f"Job has no attribute '{key}'")
+                setattr(self, key, value)
+            self.updated_at = datetime.utcnow()
+
+    def set_total_bytes(self, total: Optional[int]) -> None:
+        with self.lock:
+            self.total_bytes = total
+            self.progress = (self.bytes_downloaded / total) if total else None
+            self.updated_at = datetime.utcnow()
+
+    def bump_downloaded(self, amount: int) -> None:
+        with self.lock:
+            self.bytes_downloaded += amount
+            if self.total_bytes:
+                self.progress = min(self.bytes_downloaded / self.total_bytes, 1.0)
+            self.updated_at = datetime.utcnow()
+
+    def set_progress(self, progress: Optional[float], detail: Optional[str] = None) -> None:
+        with self.lock:
+            self.progress = progress
+            if detail is not None:
+                self.stage_detail = detail
+            self.updated_at = datetime.utcnow()
+
+    def set_stage(self, stage: str, status: Optional[JobStatus] = None, detail: Optional[str] = None) -> None:
+        with self.lock:
+            self.stage = stage
+            if status is not None:
+                self.status = status
+            if detail is not None:
+                self.stage_detail = detail
+            self.updated_at = datetime.utcnow()
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return a serialisable snapshot of the job state."""
+
+        with self.lock:
+            return {
+                "id": self.id,
+                "url": self.url,
+                "status": self.status.value,
+                "stage": self.stage,
+                "stage_detail": self.stage_detail,
+                "progress": self.progress,
+                "bytes_downloaded": self.bytes_downloaded,
+                "total_bytes": self.total_bytes,
+                "message": self.message,
+                "archive_path": str(self.archive_path),
+                "extract_path": str(self.extract_path),
+                "index_path": str(self.index_path),
+                "created_at": self.created_at.isoformat() + "Z",
+                "updated_at": self.updated_at.isoformat() + "Z",
+            }
+
+
+class JobInfo(BaseModel):
+    """Public API view of a job."""
+
+    id: str
+    url: str
+    status: JobStatus
+    stage: str
+    stage_detail: Optional[str] = None
+    progress: Optional[float] = None
+    bytes_downloaded: int
+    total_bytes: Optional[int] = None
+    message: Optional[str] = None
+    archive_path: str
+    extract_path: str
+    index_path: str
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_job(cls, job: Job) -> "JobInfo":
+        data = job.snapshot()
+        created_at = _parse_iso8601(data["created_at"])
+        updated_at = _parse_iso8601(data["updated_at"])
+        return cls(
+            id=data["id"],
+            url=data["url"],
+            status=JobStatus(data["status"]),
+            stage=data["stage"],
+            stage_detail=data["stage_detail"],
+            progress=data["progress"],
+            bytes_downloaded=data["bytes_downloaded"],
+            total_bytes=data["total_bytes"],
+            message=data["message"],
+            archive_path=data["archive_path"],
+            extract_path=data["extract_path"],
+            index_path=data["index_path"],
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+
+def _parse_iso8601(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,17 @@
+"""Utility helpers for the backup manager."""
+
+from __future__ import annotations
+
+
+def human_readable_bytes(value: int, precision: int = 1) -> str:
+    """Format a byte count as a human readable string."""
+
+    if value < 1024:
+        return f"{value} B"
+    units = ["KiB", "MiB", "GiB", "TiB", "PiB"]
+    scaled = float(value)
+    for unit in units:
+        scaled /= 1024.0
+        if scaled < 1024.0:
+            return f"{scaled:.{precision}f} {unit}"
+    return f"{scaled:.{precision}f} EiB"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "chatgpt-backup-manager"
+version = "0.1.0"
+description = "Web-based text UI for downloading, unpacking, and indexing ChatGPT backups"
+readme = "README.md"
+authors = [{name = "OpenAI Assistant"}]
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.29.0",
+    "httpx>=0.27.0",
+    "jinja2>=3.1.0",
+    "python-multipart>=0.0.9"
+]
+
+[build-system]
+requires = ["setuptools>=67.0"]
+build-backend = "setuptools.build_meta"

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ title or "ChatGPT Backup Manager" }}</title>
+    <style>
+        body {
+            font-family: "Fira Code", "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+            background-color: #111;
+            color: #eee;
+            margin: 0;
+            padding: 2rem;
+        }
+        a { color: #8be9fd; }
+        h1, h2, h3 { color: #50fa7b; }
+        form { margin-bottom: 2rem; }
+        input[type="text"], input[type="url"], select {
+            width: 100%;
+            padding: 0.6rem;
+            background-color: #1e1e1e;
+            border: 1px solid #444;
+            color: #f8f8f2;
+        }
+        button {
+            padding: 0.6rem 1.2rem;
+            background-color: #44475a;
+            color: #f8f8f2;
+            border: none;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #6272a4;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 1rem;
+        }
+        th, td {
+            padding: 0.4rem 0.6rem;
+            border-bottom: 1px solid #333;
+            text-align: left;
+        }
+        .muted {
+            color: #888;
+        }
+        .error {
+            color: #ff5555;
+        }
+        .notice {
+            background-color: #202020;
+            padding: 1rem;
+            border: 1px solid #333;
+            margin-bottom: 1rem;
+        }
+        .progress-bar {
+            background-color: #333;
+            border: 1px solid #555;
+            height: 1rem;
+            width: 100%;
+            position: relative;
+        }
+        .progress-bar span {
+            display: block;
+            height: 100%;
+            background-color: #50fa7b;
+        }
+        .layout {
+            max-width: 960px;
+            margin: 0 auto;
+        }
+    </style>
+</head>
+<body>
+<div class="layout">
+    <header>
+        <h1>ChatGPT Backup Manager</h1>
+        <p class="muted">Manage downloads of humongous backup archives without breaking a sweat.</p>
+        <nav>
+            <a href="/">Home</a> | <a href="/search">Search</a>
+        </nav>
+    </header>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="notice">
+    <h2>Ingest a new backup</h2>
+    <p>Paste the direct download URL from the OpenAI export email. The download manager will stream the
+       archive reliably, resume partial downloads, and keep the interface responsive.</p>
+    <form method="post" action="/jobs">
+        <label for="url">Backup download link</label>
+        <input type="url" id="url" name="url" placeholder="https://.../chatgpt-export.zip" required>
+        <p class="muted">We never send the link anywhere else—everything happens on your machine.</p>
+        <button type="submit">Start download</button>
+    </form>
+</section>
+
+<section>
+    <h2>Tracked jobs</h2>
+    {% if jobs %}
+        <table>
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Status</th>
+                <th>Progress</th>
+                <th>Details</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for job in jobs %}
+                <tr>
+                    <td><a href="{{ url_for('job_detail', job_id=job.id) }}">{{ job.id }}</a></td>
+                    <td>{{ job.status.value }}</td>
+                    <td>
+                        {% if job.progress is not none %}
+                            {% set percent = (job.progress * 100) | round(1) %}
+                            <div class="progress-bar"><span style="width: {{ percent }}%"></span></div>
+                            <div class="muted">{{ percent }}%</div>
+                        {% else %}
+                            <span class="muted">calculating…</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {{ job.stage }}{% if job.stage_detail %} — {{ job.stage_detail }}{% endif %}
+                    </td>
+                    <td>
+                        {% if job.status.value == 'completed' %}
+                            <a href="{{ url_for('search', job_id=job.id) }}">Search</a>
+                        {% else %}
+                            <span class="muted">pending</span>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p class="muted">No jobs yet. Drop in a link and we will do the heavy lifting.</p>
+    {% endif %}
+</section>
+{% endblock %}

--- a/templates/job.html
+++ b/templates/job.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block content %}
+<section>
+    <h2>Job {{ job.id }}</h2>
+    <p>Status: <strong>{{ job.status.value }}</strong></p>
+    <p>Stage: {{ job.stage }}{% if job.stage_detail %} — {{ job.stage_detail }}{% endif %}</p>
+    {% if job.progress is not none %}
+        {% set percent = (job.progress * 100) | round(1) %}
+        <div class="progress-bar"><span style="width: {{ percent }}%"></span></div>
+        <p class="muted">{{ percent }}% complete</p>
+    {% endif %}
+    {% if job.message %}
+        <p class="error">{{ job.message }}</p>
+    {% endif %}
+    <dl>
+        <dt>Source URL</dt>
+        <dd><code>{{ job.url }}</code></dd>
+        <dt>Downloaded bytes</dt>
+        <dd>{{ job.bytes_downloaded }}{% if job.total_bytes %} / {{ job.total_bytes }}{% endif %}</dd>
+        <dt>Archive path</dt>
+        <dd><code>{{ job.archive_path }}</code></dd>
+        <dt>Extraction directory</dt>
+        <dd><code>{{ job.extract_path }}</code></dd>
+        <dt>Search index</dt>
+        <dd><code>{{ job.index_path }}</code></dd>
+        <dt>Created</dt>
+        <dd>{{ job.created_at }}</dd>
+        <dt>Last updated</dt>
+        <dd>{{ job.updated_at }}</dd>
+    </dl>
+    <p>
+        {% if job.status.value == 'completed' %}
+            <a href="{{ url_for('search', job_id=job.id) }}">Start searching this backup</a>
+        {% else %}
+            <span class="muted">Index not ready yet. This page refreshes cleanly—no spinning beach balls.</span>
+        {% endif %}
+    </p>
+</section>
+{% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block content %}
+<section>
+    <h2>Search indexed conversations</h2>
+    {% if not jobs %}
+        <p class="muted">No backups indexed yet. Start a download from the home page first.</p>
+    {% else %}
+        <form method="get" action="/search">
+            <label for="job">Choose backup</label>
+            <select id="job" name="job_id" required>
+                <option value="" disabled {% if not selected_job %}selected{% endif %}>Select a job…</option>
+                {% for job in jobs %}
+                    <option value="{{ job.id }}" {% if selected_job and selected_job.id == job.id %}selected{% endif %}>
+                        {{ job.id }} — {{ job.status.value }}
+                    </option>
+                {% endfor %}
+            </select>
+            <label for="query">Search query</label>
+            <input type="text" id="query" name="q" value="{{ query }}" placeholder="Ask a question or search for a phrase" required>
+            <button type="submit">Search</button>
+        </form>
+        {% if error %}
+            <p class="error">{{ error }}</p>
+        {% endif %}
+        {% if results %}
+            <h3>Results</h3>
+            <ul>
+                {% for item in results %}
+                    <li>
+                        <strong>{{ item.title or 'Untitled conversation' }}</strong>
+                        {% if item.timestamp %}
+                            <span class="muted">({{ item.timestamp }})</span>
+                        {% endif %}
+                        <pre>{{ item.snippet }}</pre>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% elif selected_job and query %}
+            <p class="muted">No matches found for this query.</p>
+        {% endif %}
+    {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build a FastAPI application with a text-focused interface for managing massive ChatGPT backup archives
- implement background download, extraction, and indexing pipelines with a resumable downloader and SQLite FTS search
- document project usage, dependencies, and structure while adding templates and packaging metadata

## Testing
- python -m compileall app
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfd00e7128832aa3945270b6f70cea