### PR TITLE
Persist and resume jobs across restarts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,11 @@ async def get_manager() -> JobManager:
     return manager
 
 
+@app.on_event("startup")
+async def _startup_manager() -> None:
+    await manager.startup()
+
+
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request, manager: JobManager = Depends(get_manager)) -> HTMLResponse:
     jobs = await manager.list_jobs()

--- a/app/manager.py
+++ b/app/manager.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
-from typing import Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 import httpx
@@ -21,10 +23,28 @@ class JobManager:
     """Coordinates download, extraction, and indexing of backups."""
 
     def __init__(self) -> None:
+        self._jobs_file: Path = config.DATA_DIR / "jobs.json"
         self._jobs: Dict[str, Job] = {}
         self._lock = asyncio.Lock()
+        self._storage_lock = asyncio.Lock()
+        self._startup_lock = asyncio.Lock()
+        self._resume_job_ids: List[str] = []
+        self._load_jobs()
+        self._startup_complete = not bool(self._resume_job_ids)
+
+    async def startup(self) -> None:
+        """Reconcile jobs persisted from previous runs."""
+
+        if self._startup_complete:
+            return
+        async with self._startup_lock:
+            if self._startup_complete:
+                return
+            await self._reconcile_startup_jobs()
+            self._startup_complete = True
 
     async def create_job(self, url: str) -> Job:
+        await self.startup()
         job_id = uuid4().hex
         archive_path = config.DOWNLOAD_DIR / f"{job_id}.zip"
         extract_path = config.EXTRACT_DIR / job_id
@@ -38,15 +58,18 @@ class JobManager:
         )
         async with self._lock:
             self._jobs[job_id] = job
+        await self._persist_jobs()
         asyncio.create_task(self._run_job(job))
         return job
 
     async def list_jobs(self) -> List[JobInfo]:
+        await self.startup()
         async with self._lock:
             jobs = list(self._jobs.values())
         return [JobInfo.from_job(job) for job in jobs]
 
     async def get_job(self, job_id: str) -> Optional[JobInfo]:
+        await self.startup()
         async with self._lock:
             job = self._jobs.get(job_id)
         if job is None:
@@ -54,10 +77,12 @@ class JobManager:
         return JobInfo.from_job(job)
 
     async def get_job_internal(self, job_id: str) -> Optional[Job]:
+        await self.startup()
         async with self._lock:
             return self._jobs.get(job_id)
 
     async def search(self, job_id: str, query: str, limit: int = 25) -> List[dict[str, str]]:
+        await self.startup()
         job = await self.get_job_internal(job_id)
         if not job:
             raise KeyError(f"No job with id {job_id}")
@@ -68,22 +93,28 @@ class JobManager:
     async def _run_job(self, job: Job) -> None:
         try:
             job.set_stage("queued", JobStatus.PENDING, detail="Awaiting processing")
+            await self._persist_jobs()
             await asyncio.sleep(0)
             await self._download(job)
             job.set_stage("downloaded", JobStatus.DOWNLOADED, detail="Archive downloaded")
+            await self._persist_jobs()
             await self._extract(job)
             job.set_stage("extracted", JobStatus.EXTRACTED, detail="Files unpacked")
+            await self._persist_jobs()
             await self._index(job)
             job.set_stage("completed", JobStatus.COMPLETED, detail="Index ready")
             job.set_progress(1.0)
+            await self._persist_jobs()
         except Exception as exc:  # pragma: no cover - safety net
             logger.exception("Job %s failed", job.id)
             job.set_stage("failed", JobStatus.FAILED, detail=str(exc))
             job.update(message=str(exc))
+            await self._persist_jobs()
 
     async def _download(self, job: Job) -> None:
         job.set_stage("downloading", JobStatus.DOWNLOADING, detail="Starting download")
         job.set_progress(0.0)
+        await self._persist_jobs()
         retries = 3
         backoff = 2
         last_error: Optional[Exception] = None
@@ -96,8 +127,9 @@ class JobManager:
                 wait_for = backoff ** attempt
                 job.set_stage(
                     "downloading",
-                    detail=f"Retry {attempt}/{retries} after error: {exc}"
+                    detail=f"Retry {attempt}/{retries} after error: {exc}",
                 )
+                await self._persist_jobs()
                 await asyncio.sleep(wait_for)
         raise RuntimeError(f"Download failed after {retries} attempts: {last_error}")
 
@@ -120,6 +152,7 @@ class JobManager:
                     if job.archive_path.exists():
                         job.archive_path.unlink()
                     job.update(bytes_downloaded=0)
+                    await self._persist_jobs()
                 total = response.headers.get("Content-Length")
                 if total is not None:
                     total_bytes = int(total)
@@ -128,8 +161,10 @@ class JobManager:
                 else:
                     total_bytes = None
                 job.set_total_bytes(total_bytes)
+                await self._persist_jobs()
                 if resume_position:
                     job.update(bytes_downloaded=resume_position)
+                    await self._persist_jobs()
                 mode = "ab" if resume_position else "wb"
                 with open(job.archive_path, mode) as file_handle:
                     async for chunk in response.aiter_bytes(config.DEFAULT_DOWNLOAD_CHUNK_SIZE):
@@ -144,14 +179,99 @@ class JobManager:
     async def _extract(self, job: Job) -> None:
         job.set_stage("extracting", JobStatus.EXTRACTING, detail="Unpacking archive")
         job.set_progress(0.0)
+        await self._persist_jobs()
         await asyncio.to_thread(extract_archive, job)
         job.set_progress(1.0, detail="Extraction complete")
+        await self._persist_jobs()
 
     async def _index(self, job: Job) -> None:
         job.set_stage("indexing", JobStatus.INDEXING, detail="Creating search index")
         job.set_progress(0.0)
+        await self._persist_jobs()
         await asyncio.to_thread(indexer.build_index_for_job, job)
         job.set_progress(1.0, detail="Indexing finished")
+        await self._persist_jobs()
+
+    def _load_jobs(self) -> None:
+        if not self._jobs_file.exists():
+            return
+        try:
+            raw = self._jobs_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Unable to read job persistence file %s: %s", self._jobs_file, exc)
+            return
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Ignoring corrupt job persistence file %s", self._jobs_file)
+            return
+        if not isinstance(data, list):
+            logger.warning("Unexpected job persistence format in %s", self._jobs_file)
+            return
+        dirty = False
+        for item in data:
+            try:
+                job = Job.from_snapshot(item)
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("Failed to restore job from snapshot")
+                dirty = True
+                continue
+            self._jobs[job.id] = job
+            if job.status in {JobStatus.COMPLETED, JobStatus.FAILED}:
+                continue
+            if not job.url:
+                job.set_stage(
+                    "failed",
+                    JobStatus.FAILED,
+                    detail="Missing source URL; cannot resume",
+                )
+                job.update(message="Job missing source URL when restarting")
+                dirty = True
+                continue
+            self._resume_job_ids.append(job.id)
+        if dirty:
+            self._persist_jobs_sync()
+
+    async def _reconcile_startup_jobs(self) -> None:
+        async with self._lock:
+            jobs_to_resume = [
+                self._jobs[job_id] for job_id in self._resume_job_ids if job_id in self._jobs
+            ]
+        if not jobs_to_resume:
+            self._resume_job_ids.clear()
+            return
+        logger.info("Re-queuing %d job(s) interrupted by restart", len(jobs_to_resume))
+        for job in jobs_to_resume:
+            job.set_stage("queued", JobStatus.PENDING, detail="Re-queued after restart")
+            job.set_progress(None)
+            job.update(message="Job automatically re-queued after restart")
+        await self._persist_jobs()
+        self._resume_job_ids.clear()
+        for job in jobs_to_resume:
+            asyncio.create_task(self._run_job(job))
+
+    def _persist_jobs_sync(self) -> None:
+        snapshots = [job.snapshot() for job in self._jobs.values()]
+        try:
+            self._write_jobs_file(snapshots)
+        except OSError as exc:  # pragma: no cover - logs failure
+            logger.error("Failed to synchronously persist jobs: %s", exc)
+
+    async def _persist_jobs(self) -> None:
+        async with self._lock:
+            snapshots = [job.snapshot() for job in self._jobs.values()]
+        async with self._storage_lock:
+            try:
+                await asyncio.to_thread(self._write_jobs_file, snapshots)
+            except OSError as exc:  # pragma: no cover - log only
+                logger.error("Failed to persist jobs: %s", exc)
+
+    def _write_jobs_file(self, snapshots: List[dict[str, Any]]) -> None:
+        self._jobs_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp_file = self._jobs_file.with_suffix(self._jobs_file.suffix + ".tmp")
+        with tmp_file.open("w", encoding="utf-8") as handle:
+            json.dump(snapshots, handle, indent=2, sort_keys=True)
+        tmp_file.replace(self._jobs_file)
 
 
 def _format_download_detail(job: Job) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for ensuring the application package is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_manager_restart.py
+++ b/tests/test_manager_restart.py
@@ -1,0 +1,109 @@
+"""Regression tests for JobManager restart behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from app import config
+from app.manager import JobManager
+from app.models import Job, JobStatus
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch) -> Path:
+    data_dir = tmp_path / "data"
+    downloads = data_dir / "downloads"
+    extracted = data_dir / "extracted"
+    indexes = data_dir / "indexes"
+    tmp_dir = data_dir / "tmp"
+    for path in (data_dir, downloads, extracted, indexes, tmp_dir):
+        path.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(config, "DATA_DIR", data_dir)
+    monkeypatch.setattr(config, "DOWNLOAD_DIR", downloads)
+    monkeypatch.setattr(config, "EXTRACT_DIR", extracted)
+    monkeypatch.setattr(config, "INDEX_DIR", indexes)
+    monkeypatch.setattr(config, "TMP_DIR", tmp_dir)
+    return data_dir
+
+
+def test_restart_requeues_incomplete_jobs(isolated_data_dir: Path, monkeypatch) -> None:
+    async def run() -> None:
+        job = Job(
+            id="job123",
+            url="https://example.com/archive.zip",
+            archive_path=config.DOWNLOAD_DIR / "job123.zip",
+            extract_path=config.EXTRACT_DIR / "job123",
+            index_path=config.INDEX_DIR / "job123.sqlite3",
+            status=JobStatus.DOWNLOADING,
+            stage="downloading",
+            stage_detail="Halfway",
+            progress=0.5,
+            bytes_downloaded=128,
+            total_bytes=256,
+        )
+        jobs_file = config.DATA_DIR / "jobs.json"
+        jobs_file.write_text(json.dumps([job.snapshot()]), encoding="utf-8")
+
+        manager = JobManager()
+
+        run_calls: list[str] = []
+
+        async def fake_run(resumed_job: Job) -> None:
+            run_calls.append(resumed_job.id)
+
+        monkeypatch.setattr(manager, "_run_job", fake_run)
+
+        await manager.startup()
+        await asyncio.sleep(0)
+
+        assert run_calls == [job.id]
+
+        info = await manager.get_job(job.id)
+        assert info is not None
+        assert info.status == JobStatus.PENDING
+        assert info.stage == "queued"
+        assert info.stage_detail == "Re-queued after restart"
+        assert info.message == "Job automatically re-queued after restart"
+
+        persisted = json.loads(jobs_file.read_text(encoding="utf-8"))
+        assert persisted[0]["status"] == JobStatus.PENDING.value
+        assert persisted[0]["stage"] == "queued"
+        assert persisted[0]["message"] == "Job automatically re-queued after restart"
+
+    asyncio.run(run())
+
+
+def test_restart_marks_jobs_failed_without_source(isolated_data_dir: Path) -> None:
+    async def run() -> None:
+        job = Job(
+            id="missing-url",
+            url="",
+            archive_path=config.DOWNLOAD_DIR / "missing-url.zip",
+            extract_path=config.EXTRACT_DIR / "missing-url",
+            index_path=config.INDEX_DIR / "missing-url.sqlite3",
+            status=JobStatus.DOWNLOADING,
+            stage="downloading",
+        )
+        jobs_file = config.DATA_DIR / "jobs.json"
+        jobs_file.write_text(json.dumps([job.snapshot()]), encoding="utf-8")
+
+        manager = JobManager()
+        await manager.startup()
+
+        info = await manager.get_job(job.id)
+        assert info is not None
+        assert info.status == JobStatus.FAILED
+        assert info.stage == "failed"
+        assert info.stage_detail == "Missing source URL; cannot resume"
+        assert info.message == "Job missing source URL when restarting"
+
+        persisted = json.loads(jobs_file.read_text(encoding="utf-8"))
+        assert persisted[0]["status"] == JobStatus.FAILED.value
+        assert persisted[0]["stage"] == "failed"
+        assert persisted[0]["message"] == "Job missing source URL when restarting"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- load persisted jobs during JobManager initialisation and reconcile interrupted runs on startup
- persist job state after lifecycle updates and expose a FastAPI startup hook
- add regression coverage for restart scenarios and normalise job snapshot serialisation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfd3fc95a0832aad7e16f77062e082